### PR TITLE
fix: Fixed typo in `believe`->`belief`

### DIFF
--- a/document.tex
+++ b/document.tex
@@ -75,7 +75,7 @@ A summary of this timeline can be found in Table \ref{tbl:timeline}.
 
 The two main deliverables for CS comps is the code from the project, submitted together with its documentation as a GitHub link, and a paper about the project.
 While the code component is straightforward and uncontroversial, some students may chafe against the idea of a paper.
-Contrary to popular believe, the job of a software engineer does not only involve writing code.
+Contrary to popular belief, the job of a software engineer does not only involve writing code.
 It also requires a large amount of written communication, such as tickets for bugs reports, proposals for new features and why it will improve the product, comments on why a class is necessary or how a function works, and documentation of the system architecture.
 As software engineers rise from junior to senior positions, these responsibilities only increase.
 It is often lamented that not enough engineers know how to write \cite{Mei2018WhyDevelopersShould,Alton2020WhyEveryDeveloper}, which is why Google has created courses on technical writing \cite{GoogleTechnicalWriting}, and ``soft skills'' are routinely touted as necessary for software developers \cite{Indeed202111ImportantSoft}.


### PR DESCRIPTION
This fixes a small typo that I noticed in this sentence:

> Contrary to popular believe, the job...

to

> Contrary to popular belief, the job...